### PR TITLE
Add ability to restrict the scope to the namespace

### DIFF
--- a/charts/kubeview/Chart.yaml
+++ b/charts/kubeview/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: sebastien-prudhomme
     email: sebastien.prudhomme@gmail.com
 name: kubeview
-version: 1.0.3
+version: 1.1.0

--- a/charts/kubeview/README.md
+++ b/charts/kubeview/README.md
@@ -69,6 +69,7 @@ The following table lists all the configurable parameters expose by the KubeView
 | `serviceAccount.create`      | Specify whether to create a ServiceAccount                                                    | `true`                                           |
 | `serviceAccount.annotations` | ServiceAccount annotations                                                                    | `{}`                                             |
 | `serviceAccount.name`        | The name of the ServiceAccount to create                                                      | Generated using the `kubeview.fullname` template |
+| `serviceAccount.namespaced`  | Whether ServiceAccount has access to all cluster resources or just these inside the namespace | `false`                                          |
 | `podSecurityContext`         | Pod security context                                                                          | `{}`                                             |
 | `securityContext`            | Container security context                                                                    | `{}`                                             |
 | `service.type`               | Kubernetes Service type                                                                       | `ClusterIP`                                      |

--- a/charts/kubeview/templates/clusterrole.yaml
+++ b/charts/kubeview/templates/clusterrole.yaml
@@ -1,5 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.serviceAccount.namespaced }}
+kind: Role
+{{ else }}
 kind: ClusterRole
+{{ end -}}
 metadata:
   name: {{ include "kubeview.fullname" . }}
   labels:
@@ -29,5 +33,7 @@ rules:
       - resourcequotas
       - services
     verbs: ["get", "list"]
+{{- if not .Values.serviceAccount.namespaced }}
   - nonResourceURLs: ["*"]
     verbs: ["get", "list"]
+{{- end -}}

--- a/charts/kubeview/templates/clusterrolebinding.yaml
+++ b/charts/kubeview/templates/clusterrolebinding.yaml
@@ -1,12 +1,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.serviceAccount.namespaced }}
+kind: RoleBinding
+{{ else }}
 kind: ClusterRoleBinding
+{{ end -}}
 metadata:
   name: {{ include "kubeview.fullname" . }}
   labels:
     {{- include "kubeview.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.serviceAccount.namespaced }}
+  kind: Role
+  {{ else }}
   kind: ClusterRole
+  {{ end -}}
   name: {{ include "kubeview.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/kubeview/values.yaml
+++ b/charts/kubeview/values.yaml
@@ -21,6 +21,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  namespaced: false
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
When using a shared cluster I have no permissions to deploy a ClusterRole
and a ClusterRoleBinding. But I can deploy KubeView inside the
namespace I want to visualize.

Known issue: The dropdown menu to select the namespace to visualize is
empty because kubeview has no access to list namespaces. Just enter the
namespace you deployed kubeview in and press enter.