### PR TITLE
Add podLabels to Mongo Express deployment

### DIFF
--- a/charts/mongo-express/Chart.yaml
+++ b/charts/mongo-express/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: sebastien-prudhomme
     email: sebastien.prudhomme@gmail.com
 name: mongo-express
-version: 1.0.1
+version: 1.0.2

--- a/charts/mongo-express/README.md
+++ b/charts/mongo-express/README.md
@@ -66,6 +66,7 @@ The following table lists all the configurable parameters expose by the Mongo Ex
 | `imagePullSecrets`           | Docker registry secret names as an array                                                           | `[]`                                                  |
 | `nameOverride`               | Partially override `mongo-express.fullname` template with a string (will prepend the release name) | `nil`                                                 |
 | `fullnameOverride`           | Fully override `mongo-express.fullname` template with a string                                     | `nil`                                                 |
+| `podLabels`                  | Specify labels to the Pod                                                                           | `[]`                                                  |
 | `serviceAccount.create`      | Specify whether to create a ServiceAccount                                                         | `true`                                                |
 | `serviceAccount.annotations` | ServiceAccount annotations                                                                         | `{}`                                                  |
 | `serviceAccount.name`        | The name of the ServiceAccount to create                                                           | Generated using the `mongo-express.fullname` template |

--- a/charts/mongo-express/templates/deployment.yaml
+++ b/charts/mongo-express/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
   template:
     metadata:
       labels:
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
         {{- include "mongo-express.selectorLabels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-          {{ toYaml .Values.podLabels | indent 8 }}
-        {{- end }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:

--- a/charts/mongo-express/templates/deployment.yaml
+++ b/charts/mongo-express/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "mongo-express.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+          {{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:

--- a/charts/mongo-express/values.yaml
+++ b/charts/mongo-express/values.yaml
@@ -12,6 +12,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+podLabels: []
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This allows somebody to add custom labels to a Pod in addition to the selector labels.