### PR TITLE
fix(vertical-pod-autoscaler): rename admission controller service port name

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
   - name: sebastien-prudhomme
     email: sebastien.prudhomme@gmail.com
 name: vertical-pod-autoscaler
-version: 1.4.3
+version: 1.4.4

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
@@ -12,6 +12,6 @@ spec:
     - port: 443
       targetPort: http
       protocol: TCP
-      name: http
+      name: https
   selector:
     {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
This resolves issue where istio service mesh blocks outbound https traffic.

Related https://github.com/cowboysysop/charts/issues/33
