### PR TITLE
fix(vertical-pod-autoscaler): add missing namespace env variable

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
   - name: sebastien-prudhomme
     email: sebastien.prudhomme@gmail.com
 name: vertical-pod-autoscaler
-version: 2.2.0
+version: 2.2.1

--- a/charts/vertical-pod-autoscaler/README.md
+++ b/charts/vertical-pod-autoscaler/README.md
@@ -15,7 +15,7 @@ This chart bootstraps a Vertical Pod Autoscaler deployment on a [Kubernetes](htt
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.16+
 - Metrics Server 0.2+ (you can use the [stable/metrics-server](https://hub.helm.sh/charts/stable/metrics-server) chart)
 - Helm 2.11+
 

--- a/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -38,6 +38,11 @@ spec:
             {{- range $key, $value := .Values.updater.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: http-metrics
               containerPort: 8943


### PR DESCRIPTION
Fix for issue #45

Also update Kubernetes minimum version for Vertical Pod Autoscaler 0.9+