### PR TITLE
add support for external postgres ssl connectivity in lighthouse-ci

### DIFF
--- a/charts/lighthouse-ci/README.md
+++ b/charts/lighthouse-ci/README.md
@@ -153,6 +153,7 @@ The following table lists all the configurable parameters expose by the Lighthou
 | `externalPostgresql.password`        | External PostgreSQL password                                                                          | `lighthouse-ci`                                       |
 | `externalPostgresql.existingSecret`  | Name of existing Secret to use                                                                        | `nil`                                                 |
 | `externalPostgresql.database`        | External PostgreSQL database                                                                          | `lighthouse-ci`                                       |
+| `externalPostgresql.ssl`             | External PostgreSQL SSL Connectivity                                                                  | `false`                                               |
 
 Specify the parameters you which to customize using the `--set` argument to the `helm install` command. For instance,
 

--- a/charts/lighthouse-ci/templates/deployment.yaml
+++ b/charts/lighthouse-ci/templates/deployment.yaml
@@ -87,6 +87,12 @@ spec:
               value: {{ include "lighthouse-ci.postgresql.database" . | quote }}
             - name: LHCI_STORAGE__SQL_CONNECTION_URL
               value: "postgres://$(POSTGRESQL_USERNAME):$(POSTGRESQL_PASSWORD)@$(POSTGRESQL_HOST):$(POSTGRESQL_PORT)/$(POSTGRESQL_DATABASE)"
+            {{- if .Values.externalPostgresql.ssl }}
+            - name: LHCI_STORAGE__SQL_CONNECTION_SSL
+              value: 'true'
+            - name: LHCI_STORAGE__SQL_DIALECT_OPTIONS__SSL
+              value: 'true'
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/charts/lighthouse-ci/values.yaml
+++ b/charts/lighthouse-ci/values.yaml
@@ -283,3 +283,6 @@ externalPostgresql:
 
   # External PostgreSQL database
   database: lighthouse-ci
+
+  # Enable PostgreSQL SSL connectivity
+  ssl: false


### PR DESCRIPTION
adds feature #70 