### PR TITLE
fix(vertical-pod-autoscaler): use dedicated path for probes

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 4.0.2
+version: 4.0.3
 dependencies:
   - name: common
     version: 1.7.1

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           {{- if .Values.admissionController.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.admissionController.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.admissionController.livenessProbe.periodSeconds }}
@@ -97,7 +97,7 @@ spec:
           {{- if .Values.admissionController.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.admissionController.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.admissionController.readinessProbe.periodSeconds }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           {{- if .Values.recommender.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.recommender.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.recommender.livenessProbe.periodSeconds }}
@@ -89,7 +89,7 @@ spec:
           {{- if .Values.recommender.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.recommender.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.recommender.readinessProbe.periodSeconds }}

--- a/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           {{- if .Values.updater.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.updater.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.updater.livenessProbe.periodSeconds }}
@@ -92,7 +92,7 @@ spec:
           {{- if .Values.updater.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /health-check
               port: http-metrics
             initialDelaySeconds: {{ .Values.updater.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.updater.readinessProbe.periodSeconds }}


### PR DESCRIPTION
Using /metrics generates a lot of logs in recommender pod:

```
2022/02/18 17:05:43 http: superfluous response.WriteHeader call from [github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader](http://github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader) (delegator.go:58)
2022/02/18 17:05:52 http: superfluous response.WriteHeader call from [github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader](http://github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader) (delegator.go:58)
2022/02/18 17:05:53 http: superfluous response.WriteHeader call from [github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader](http://github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader) (delegator.go:58)
2022/02/18 17:06:02 http: superfluous response.WriteHeader call from [github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader](http://github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader) (delegator.go:58)
2022/02/18 17:06:03 http: superfluous response.WriteHeader call from [github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader](http://github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader) (delegator.go:58)
```