### PR TITLE
vpa crds job pod annotations

### DIFF
--- a/charts/vertical-pod-autoscaler/README.md
+++ b/charts/vertical-pod-autoscaler/README.md
@@ -282,6 +282,7 @@ The following tables lists all the configurable parameters expose by the chart a
 | `crds.image.tag`        | Image tag                      | `1.23.1`          |
 | `crds.image.pullPolicy` | Image pull policy              | `IfNotPresent`    |
 | `crds.nodeSelector`     | Node labels for pod assignment | `{}`              |
+| `crds.podAnnotations`   | Additional pod annotations     | `{}`              |
 | `crds.tolerations`      | Tolerations for pod assignment | `[]`              |
 | `crds.affinity`         | Map of node/pod affinities     | `{}`              |
 

--- a/charts/vertical-pod-autoscaler/templates/crds/job.yaml
+++ b/charts/vertical-pod-autoscaler/templates/crds/job.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- end }}
 spec:
   template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.crds.podAnnotations | trim | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -549,6 +549,8 @@ crds:
 
   nodeSelector: {}
 
+  podAnnotations: {}
+
   tolerations: []
 
   affinity: {}


### PR DESCRIPTION
Adds `crds.podAnnotations` to values.yaml => annotations for pod(s) spawned via the crds job.

Annotations for the crds job pod was required to avoid istio sidecar, similar to: https://github.com/open-policy-agent/gatekeeper/pull/2115