### PR TITLE
[whoami] Switch to traefik last version

### DIFF
--- a/charts/whoami/Chart.yaml
+++ b/charts/whoami/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
-appVersion: 1.5.0
+appVersion: 1.8.6
 description: Tiny Go webserver that prints os information and HTTP request to output
-home: https://github.com/containous/whoami
+home: https://github.com/traefik/whoami
 maintainers:
   - name: sebastien-prudhomme
     email: sebastien.prudhomme@gmail.com
 name: whoami
 sources:
-  - https://github.com/containous/whoami
+  - https://github.com/traefik/whoami
   - https://github.com/cowboysysop/charts/tree/master/charts/whoami
-version: 2.6.0
+version: 2.7.0
 dependencies:
   - name: common
     version: 1.16.1

--- a/charts/whoami/README.md
+++ b/charts/whoami/README.md
@@ -1,6 +1,6 @@
 # Whoami
 
-[Whoami](https://github.com/containous/whoami) is a tiny Go webserver that prints os information and HTTP request to output.
+[Whoami](https://github.com/traefik/whoami) is a tiny Go webserver that prints os information and HTTP request to output.
 
 **DISCLAIMER**: This is an unofficial chart not supported by Whoami authors.
 
@@ -82,8 +82,8 @@ The following tables lists all the configurable parameters expose by the chart a
 | Name                                 | Description                                                                                           | Default                                        |
 |--------------------------------------|-------------------------------------------------------------------------------------------------------|------------------------------------------------|
 | `replicaCount`                       | Number of replicas                                                                                    | `1`                                            |
-| `image.repository`                   | Image name                                                                                            | `containous/whoami`                            |
-| `image.tag`                          | Image tag                                                                                             | `v1.5.0`                                       |
+| `image.repository`                   | Image name                                                                                            | `traefik/whoami`                               |
+| `image.tag`                          | Image tag                                                                                             | `v1.8.6`                                       |
 | `image.pullPolicy`                   | Image pull policy                                                                                     | `IfNotPresent`                                 |
 | `pdb.create`                         | Specifies whether a pod disruption budget should be created                                           | `false`                                        |
 | `pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                                        | `1`                                            |

--- a/charts/whoami/values.yaml
+++ b/charts/whoami/values.yaml
@@ -21,8 +21,8 @@ extraDeploy: []
 replicaCount: 1
 
 image:
-  repository: containous/whoami
-  tag: v1.5.0
+  repository: traefik/whoami
+  tag: v1.8.6
   pullPolicy: IfNotPresent
 
 pdb:


### PR DESCRIPTION
https://github.com/traefik/whoami is the new home of whoami, and some versions have been released since 1.5.0 :)

For such a move, i've considered that bumping version to 3.0.0 should be relevant.