### PR TITLE
feat: allow VPA Admission controller deployment annotations

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 9.4.0
+version: 9.5.0
 dependencies:
   - name: common
     version: 2.13.3

--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -13,7 +13,7 @@ sources:
 version: 9.4.0
 dependencies:
   - name: common
-    version: 2.9.0
+    version: 2.13.3
     repository: https://charts.bitnami.com/bitnami/
 annotations:
   artifacthub.io/signKey: |

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -8,9 +8,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations:
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.admissionController.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.admissionController.deploymentAnnotations .Values.commonAnnotations ) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.admissionController.replicaCount }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations:
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.recommender.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.recommender.deploymentAnnotations .Values.commonAnnotations ) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.recommender.replicaCount }}

--- a/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -8,9 +8,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations:
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.updater.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.updater.deploymentAnnotations .Values.commonAnnotations ) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.updater.replicaCount }}

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -77,6 +77,9 @@ admissionController:
     ## @param admissionController.serviceAccount.name The name of the service account to use (Generated using the `vertical-pod-autoscaler.fullname` template if not set)
     name:
 
+  ## @param admissionController.deploymentAnnotations Additional deployment annotations
+  deploymentAnnotations: {}
+
   ## @param admissionController.podAnnotations Additional pod annotations
   podAnnotations: {}
 
@@ -329,6 +332,9 @@ recommender:
 
     ## @param recommender.serviceAccount.name The name of the service account to use (Generated using the `vertical-pod-autoscaler.fullname` template if not set)
     name:
+
+  ## @param recommender.deploymentAnnotations Additional deployment annotations
+  deploymentAnnotations: {}
 
   ## @param recommender.podAnnotations Additional pod annotations
   podAnnotations: {}
@@ -588,6 +594,9 @@ updater:
 
     ## @param updater.serviceAccount.name The name of the service account to use (Generated using the `vertical-pod-autoscaler.fullname` template if not set)
     name:
+
+  ## @param updater.deploymentAnnotations Additional deployment annotations
+  deploymentAnnotations: {}
 
   ## @param updater.podAnnotations Additional pod annotations
   podAnnotations: {}


### PR DESCRIPTION
Purpose: to allow specific annotations for VPA Admission controller deployment.
For example, [stakater/Reloader](https://github.com/stakater/Reloader) to restart deployment when tls-secret changed due to certificate renewal.
Br, Alexey