### PR TITLE
feat: Add support for securityContext to crd hook

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 9.5.0
+version: 9.6.0
 dependencies:
   - name: common
     version: 2.13.3

--- a/charts/vertical-pod-autoscaler/README.md
+++ b/charts/vertical-pod-autoscaler/README.md
@@ -356,19 +356,23 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 
 ### CRDs parameters
 
-| Name                    | Description                         | Default           |
-| ----------------------- | ----------------------------------- | ----------------- |
-| `crds.image.registry`   | Image registry                      | `docker.io`       |
-| `crds.image.repository` | Image repository                    | `bitnami/kubectl` |
-| `crds.image.tag`        | Image tag                           | `1.26.3`          |
-| `crds.image.digest`     | Image digest                        | `""`              |
-| `crds.image.pullPolicy` | Image pull policy                   | `IfNotPresent`    |
-| `crds.podAnnotations`   | Additional pod annotations          | `{}`              |
-| `crds.podLabels`        | Additional pod labels               | `{}`              |
-| `crds.resources`        | CPU/Memory resource requests/limits | `{}`              |
-| `crds.nodeSelector`     | Node labels for pod assignment      | `{}`              |
-| `crds.tolerations`      | Tolerations for pod assignment      | `[]`              |
-| `crds.affinity`         | Map of node/pod affinities          | `{}`              |
+| Name                                   | Description                                             | Default           |
+| -------------------------------------- | ------------------------------------------------------- | ----------------- |
+| `crds.image.registry`                  | Image registry                                          | `docker.io`       |
+| `crds.image.repository`                | Image repository                                        | `bitnami/kubectl` |
+| `crds.image.tag`                       | Image tag                                               | `1.26.3`          |
+| `crds.image.digest`                    | Image digest                                            | `""`              |
+| `crds.image.pullPolicy`                | Image pull policy                                       | `IfNotPresent`    |
+| `crds.podAnnotations`                  | Additional pod annotations                              | `{}`              |
+| `crds.podLabels`                       | Additional pod labels                                   | `{}`              |
+| `crds.podSecurityContext`              | Pod security context                                    |                   |
+| `crds.podSecurityContext.runAsNonRoot` | Whether the container must run as a non-root user       | `true`            |
+| `crds.podSecurityContext.runAsUser`    | The UID to run the entrypoint of the container process  | `65534`           |
+| `crds.resources`                       | CPU/Memory resource requests/limits                     | `{}`              |
+| `crds.nodeSelector`                    | Node labels for pod assignment                          | `{}`              |
+| `crds.crds.securityContext`            | Container security context                              |                   |
+| `crds.tolerations`                     | Tolerations for pod assignment                          | `[]`              |
+| `crds.affinity`                        | Map of node/pod affinities                              | `{}`              |
 
 ### Tests parameters
 

--- a/charts/vertical-pod-autoscaler/templates/crds/job.yaml
+++ b/charts/vertical-pod-autoscaler/templates/crds/job.yaml
@@ -47,6 +47,8 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.crds.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.crds.securityContext | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /config
@@ -59,6 +61,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.crds.podSecurityContext | nindent 8 }}
       {{- with .Values.crds.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -810,6 +810,14 @@ crds:
   ## @param crds.podLabels Additional pod labels
   podLabels: {}
 
+  ## @extra crds.podSecurityContext Pod security context
+  ## @param crds.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
+  ## @param crds.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
+  podSecurityContext:
+    # fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 65534
+
   ## @param crds.resources CPU/Memory resource requests/limits
   resources: {}
     # limits:
@@ -821,6 +829,15 @@ crds:
 
   ## @param crds.nodeSelector Node labels for pod assignment
   nodeSelector: {}
+
+  ## @param crds.securityContext Container security context
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
   ## @param crds.tolerations Tolerations for pod assignment
   tolerations: []


### PR DESCRIPTION
We're trying to install this on a cluster which mandates the Pod Security standards are followed, so we need to be able to configure the securityContext