### PR TITLE
Enabling Istio compatibility and serviceAccountTokenAutomounting settings

### DIFF
--- a/charts/kroki/Chart.yaml
+++ b/charts/kroki/Chart.yaml
@@ -10,7 +10,7 @@ name: kroki
 sources:
   - https://github.com/yuzutech/kroki
   - https://github.com/cowboysysop/charts/tree/master/charts/kroki
-version: 5.0.0
+version: 5.0.1
 dependencies:
   - name: common
     version: 2.9.0

--- a/charts/kroki/templates/deployment.yaml
+++ b/charts/kroki/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       serviceAccountName: {{ include "kroki.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kroki/templates/ingress.yaml
+++ b/charts/kroki/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
-kind: Ingress
+kind: {{ .Values.ingress.kind }}
 metadata:
   name: {{ include "kroki.fullname" . }}
   labels:

--- a/charts/kroki/templates/serviceaccount.yaml
+++ b/charts/kroki/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "kroki.serviceAccountName" . }}
   labels:

--- a/charts/kroki/values.yaml
+++ b/charts/kroki/values.yaml
@@ -36,6 +36,9 @@ extraDeploy: []
 ## @param replicaCount Number of replicas
 replicaCount: 1
 
+## @param automountServiceAccountToken Specifies whether a service account token should be automatically mounted in the pod
+automountServiceAccountToken: true
+
 image:
   ## @param image.registry Image registry
   registry: docker.io
@@ -72,6 +75,9 @@ serviceAccount:
 
   ## @param serviceAccount.name The name of the service account to use (Generated using the `kroki.fullname` template if not set)
   name:
+
+  ## @param serviceAccount.automountServiceAccountToken Specifies whether a service account token should be automatically mounted
+  automountServiceAccountToken: true
 
 ## @param podAnnotations Additional pod annotations
 podAnnotations: {}
@@ -191,6 +197,9 @@ service:
 ingress:
   ## @param ingress.enabled Enable ingress controller resource
   enabled: false
+
+  ## @param ingress.kind Ingress controller resource kind
+  kind: Ingress
 
   ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress
   ingressClassName: ""


### PR DESCRIPTION
Our interal codebase requires that we not automount service tokens and that we use Istio VirtualService in our Ingress definitions.  

So I'm adding this flags to the chart.  