### PR TITLE
add hostNetwork to admissionController for the vertical pod autoscaler chart

### DIFF
--- a/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.admissionController.podSecurityContext | nindent 8 }}
+      hostNetwork: {{.Values.admissionController.hostNetwork}}
       containers:
         - name: admission-controller
           securityContext:

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -40,6 +40,9 @@ admissionController:
   ## @param admissionController.replicaCount Number of replicas
   replicaCount: 1
 
+  ## @param admissionController.hostNetwork Enable and configure hostNetwork
+  hostNetwork: false
+
   image:
     ## @param admissionController.image.registry Image registry
     registry: registry.k8s.io


### PR DESCRIPTION
This PR adds the ability to configure the hostNetwork of the admissionsController for the vertical pod autoscaler chart. 