### PR TITLE
Flowise: Add ability to connect to PostgreSQL using SSL

### DIFF
--- a/charts/flowise/README.md
+++ b/charts/flowise/README.md
@@ -202,6 +202,7 @@ The command deletes the release named `my-release` and frees all the kubernetes 
 | `externalPostgresql.existingSecret`            | Name of existing Secret to use                           | `""`         |
 | `externalPostgresql.existingSecretKeyPassword` | Key in existing Secret that contains PostgreSQL password | `password`   |
 | `externalPostgresql.database`                  | External PostgreSQL database                             | `flowise`    |
+| `externalPostgresql.ssl`                       | Whether to connect using SSL                             | `false`      |
 
 ### Wait parameters
 

--- a/charts/flowise/templates/deployment.yaml
+++ b/charts/flowise/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - /bin/sh
             - -ec
             - |
-              wait4x postgresql "postgres://${POSTGRESQL_USERNAME}:${POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}?sslmode=disable" --timeout 0
+              wait4x postgresql "postgres://${POSTGRESQL_USERNAME}:${POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}?sslmode=${POSTGRESQL_SSL}" --timeout 0
           env:
             - name: POSTGRESQL_HOST
               value: {{ include "flowise.postgresql.host" . | quote }}
@@ -101,6 +101,8 @@ spec:
                   key: {{ include "flowise.postgresql.secretKeyPassword" . }}
             - name: POSTGRESQL_DATABASE
               value: {{ include "flowise.postgresql.database" . | quote }}
+            - name: POSTGRESQL_SSL
+              value: {{ include "flowise.postgresql.ssl" . | lower }}
           resources:
             {{- toYaml .Values.wait.resources | nindent 12 }}
         {{- end }}
@@ -177,6 +179,8 @@ spec:
                   key: {{ include "flowise.postgresql.secretKeyPassword" . }}
             - name: DATABASE_NAME
               value: {{ include "flowise.postgresql.database" . | quote }}
+            - name: POSTGRESQL_SSL
+              value: {{ include "flowise.postgresql.ssl" . | lower }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -401,6 +401,9 @@ externalPostgresql:
   ## @param externalPostgresql.database External PostgreSQL database
   database: flowise
 
+  ## @param externalPostgresql.ssl Whether to connect using SSL
+  ssl: false
+
 ## @section Wait parameters
 
 wait:


### PR DESCRIPTION
Support for connecting to PostgreSQL using SSL was added in Flowise 1.4.8: https://github.com/FlowiseAI/Flowise/releases/tag/flowise%401.4.8

Could this be added to current version (1.3.4) or does the image tag need update as well (perhaps with additional changes)?