### PR TITLE
feat(service): added session affinity to use if replicas more than 1

### DIFF
--- a/charts/flowise/templates/service.yaml
+++ b/charts/flowise/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer")  .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -33,7 +33,7 @@ extraDeploy: []
 
 ## @section Parameters
 
-## @param replicaCount Number of replicas (do not change it)
+## @param replicaCount Number of replicas (change just if you are using service.type LoadBalancer)
 replicaCount: 1
 
 updateStrategy:
@@ -180,6 +180,12 @@ service:
   ## @param service.clusterIP Static cluster IP address or None for headless service when service type is ClusterIP
   clusterIP:
   # clusterIP: 10.43.0.100
+
+  ## @param service.sessionAffinity when service type is LoadBalancer 
+  sessionAffinity:
+  # sessionAffinity: ClientIP
+  
+
 
   ## @param service.loadBalancerIP Static load balancer IP address when service type is LoadBalancer
   loadBalancerIP:


### PR DESCRIPTION
Added session affinity to fix error session id unknown when using more than 1 replica on Kubernetes