### PR TITLE
Add support for volumes and mounts

### DIFF
--- a/charts/flowise/README.md
+++ b/charts/flowise/README.md
@@ -171,6 +171,8 @@ The command deletes the release named `my-release` and frees all the kubernetes 
 | `persistence.annotations`            | PVC annotations                                                                                       | `{}`                     |
 | `persistence.size`                   | PVC size                                                                                              | `1Gi`                    |
 | `persistence.storageClass`           | PVC storage class                                                                                     | `nil`                    |
+| `extraVolumes`                       | Additional pod volumes                                                                                | `[]`                     |
+| `extraVolumeMounts`                  | Additional container volume mounts                                                                    | `[]`                     |
 
 ### Config parameters
 

--- a/charts/flowise/templates/deployment.yaml
+++ b/charts/flowise/templates/deployment.yaml
@@ -234,6 +234,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -254,3 +257,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -268,6 +268,19 @@ extraEnvVarsCM:
 ## @param extraEnvVarsSecret Name of existing Secret containing additional container environment variables
 extraEnvVarsSecret:
 
+## @param extraVolumes Additional pod volumes
+extraVolumes: []
+  # - name: aws-rds-ca
+  #   configMap:
+  #     name: aws-rds-ca
+
+## @param extraVolumeMounts Additional container volume mounts
+extraVolumeMounts: []
+  #  - name: aws-rds-ca
+  #    subPath: global-bundle.pem
+  #    mountPath: /var/run/secrets/rds.amazonaws.com/global-bundle.pem
+  #    readOnly: true
+
 persistence:
   ## @param persistence.enabled Enable persistence using PVC
   enabled: false


### PR DESCRIPTION
This adds support for mounting extra volumes. One of the use cases for this is mounting PostgreSQL CA ConfigMap.
Contributes to #593