### PR TITLE
fix(vertical-pod-autoscaler): explicitly set `podSecurityContext.runAsGroup`

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 9.8.2
+version: 9.8.3
 dependencies:
   - name: common
     version: 2.19.1

--- a/charts/vertical-pod-autoscaler/README.md
+++ b/charts/vertical-pod-autoscaler/README.md
@@ -162,6 +162,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `admissionController.podSecurityContext`                       | Pod security context                                                                                                |                                        |
 | `admissionController.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                                 |
 | `admissionController.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                                |
+| `admissionController.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                                |
 | `admissionController.hostNetwork`                              | Use the host network                                                                                                | `false`                                |
 | `admissionController.priorityClassName`                        | Priority class name                                                                                                 | `nil`                                  |
 | `admissionController.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                                   |
@@ -243,6 +244,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `recommender.podSecurityContext`                       | Pod security context                                                                                                |                               |
 | `recommender.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                        |
 | `recommender.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                       |
+| `recommender.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                       |
 | `recommender.priorityClassName`                        | Priority class name                                                                                                 | `nil`                         |
 | `recommender.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                          |
 | `recommender.topologySpreadConstraints`                | Topology Spread Constraints for pod assignment                                                                      | `[]`                          |
@@ -313,6 +315,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `updater.podSecurityContext`                       | Pod security context                                                                                                |                           |
 | `updater.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                    |
 | `updater.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                   |
+| `updater.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                   |
 | `updater.priorityClassName`                        | Priority class name                                                                                                 | `nil`                     |
 | `updater.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                      |
 | `updater.topologySpreadConstraints`                | Topology Spread Constraints for pod assignment                                                                      | `[]`                      |
@@ -374,6 +377,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `crds.podSecurityContext`              | Pod security context                                   |                   |
 | `crds.podSecurityContext.runAsNonRoot` | Whether the container must run as a non-root user      | `true`            |
 | `crds.podSecurityContext.runAsUser`    | The UID to run the entrypoint of the container process | `1001`            |
+| `crds.podSecurityContext.runAsGroup`   | The GID to run the entrypoint of the container process | `1001`            |
 | `crds.securityContext`                 | Container security context                             | `{}`              |
 | `crds.resources`                       | CPU/Memory resource requests/limits                    | `{}`              |
 | `crds.nodeSelector`                    | Node labels for pod assignment                         | `{}`              |

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -89,10 +89,12 @@ admissionController:
   ## @extra admissionController.podSecurityContext Pod security context
   ## @param admissionController.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
   ## @param admissionController.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param admissionController.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
   podSecurityContext:
     # fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 65534
+    runAsGroup: 65534
 
   ## @param admissionController.hostNetwork Use the host network
   hostNetwork: false
@@ -354,10 +356,12 @@ recommender:
   ## @extra recommender.podSecurityContext Pod security context
   ## @param recommender.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
   ## @param recommender.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param recommender.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
   podSecurityContext:
     # fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 65534
+    runAsGroup: 65534
 
   ## @param recommender.priorityClassName Priority class name
   priorityClassName:
@@ -616,10 +620,12 @@ updater:
   ## @extra updater.podSecurityContext Pod security context
   ## @param updater.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
   ## @param updater.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param updater.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
   podSecurityContext:
     # fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 65534
+    runAsGroup: 65534
 
   ## @param updater.priorityClassName Priority class name
   priorityClassName:
@@ -822,10 +828,12 @@ crds:
   ## @extra crds.podSecurityContext Pod security context
   ## @param crds.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
   ## @param crds.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param crds.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
   podSecurityContext:
     # fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1001
+    runAsGroup: 1001
 
   ## @param crds.securityContext Container security context
   securityContext: {}


### PR DESCRIPTION
This PR explicitly sets the `runAsGroup` of the VPA components.

According to the [Kubernetes API reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podsecuritycontext-v1-core) the `runAsGroup` defaults to the runtime default if not set. In reality this might be the `runAsUser` ID, but it doesn't have to.