### PR TITLE
Change default lease name for vpa-recommender to "vpa-recommender-lease" to avoid conflicts

### DIFF
--- a/charts/vertical-pod-autoscaler/templates/recommender/clusterrole.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/clusterrole.yaml
@@ -139,7 +139,8 @@ rules:
   - apiGroups:
       - "coordination.k8s.io"
     resourceNames:
-      - vpa-recommender
+      - vpa-recommender  # kept here for historical reasons
+      - vpa-recommender-lease
     resources:
       - leases
     verbs:

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -494,7 +494,7 @@ recommender:
     # leader-elect-lease-duration: 15s
     # leader-elect-renew-deadline: 10s
     # leader-elect-resource-lock: leases
-    # leader-elect-resource-name: vpa-recommender
+    # leader-elect-resource-name: vpa-recommender-lease
     # leader-elect-resource-namespace: kube-system
     # leader-elect-retry-period: 2s
     # memory-aggregation-interval: 24h0m0s


### PR DESCRIPTION
See https://github.com/kubernetes/autoscaler/issues/7461.

The default lock name can sometimes conflict with a managed deployment of VPA/HPA which can cause issues on your cluster.

Here we are proposing changing the flag value in the Helm chart to a new name (`vpa-recommender-lease`). We are keeping the old resource name in the RBAC to avoid disruptions or issues during upgrade.

I am totally open to thoughts or ideas on how we can make this better and smoother :)