### PR TITLE
vpa: support cert-manager for admission controller cert generation

### DIFF
--- a/charts/vertical-pod-autoscaler/templates/admission-controller/tls-cert.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/tls-cert.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.admissionController.enabled }}
+{{- if .Values.admissionController.enableCertManager }}
+{{- $cn := printf "%s.%s.svc" "vpa-webhook" .Release.Namespace }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "vertical-pod-autoscaler.admissionController.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  dnsNames:
+  - {{ $cn }}
+  duration: 8760h # 1 year
+  commonName: {{ $cn }}
+  issuerRef:
+    kind: Issuer
+    name: {{ template "vertical-pod-autoscaler.admissionController.fullname" . }}-selfsigned-issuer
+  secretName: {{ template "vertical-pod-autoscaler.admissionController.tls.secretName" . }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "vertical-pod-autoscaler.admissionController.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  selfSigned: {}
+{{- end }}
+{{- end }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.admissionController.enabled }}
-{{- if not .Values.admissionController.tls.existingSecret }}
+{{- if and (not .Values.admissionController.tls.existingSecret) (not .Values.admissionController.enableCertManager) }}
 {{- $ca := genCA (include "vertical-pod-autoscaler.admissionController.fullname" .) 365 }}
 {{- $cn := printf "%s.%s.svc" "vpa-webhook" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}

--- a/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/vertical-pod-autoscaler/values.yaml
@@ -312,6 +312,9 @@ admissionController:
       ## @param admissionController.metrics.serviceMonitor.relabelings Specify general relabeling
       relabelings: []
 
+  ## @param admissionController.enableCertManager Enable cert-manager
+  enableCertManager: false
+
   tls:
     ## @param admissionController.tls.caCert TLS CA certificate (Generated using the `genCA` function if not set)
     caCert: ""


### PR DESCRIPTION
This change adds support for cert-manager to handle certificate generation for the admission controller webhook instead of using Helm's built-in certificate generation.

- Prevents ArgoCD from continuously reconciling the secret.
- Improves integration with GitOps workflows.