### PR TITLE
feat(vpa): Add namespace field to all resources

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 10.0.1
+version: 10.1.0
 dependencies:
   - name: common
     version: 2.21.0

--- a/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -25,6 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "vertical-pod-autoscaler.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "vertical-pod-autoscaler.chart" -}}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrolebinding.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrolebinding.yaml
@@ -18,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.admissionController.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "vertical-pod-autoscaler.namespace" . | quote }}
 {{- end }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/metrics-service.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.metrics.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/pdb.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vpa-webhook
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/serviceaccount.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.serviceAccountName" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/servicemonitor.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.admissionController.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "vertical-pod-autoscaler.namespace" .) .Values.admissionController.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.admissionController.metrics.serviceMonitor.labels }}

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.tls.secretName" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/crds/configmap.yaml
+++ b/charts/vertical-pod-autoscaler/templates/crds/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/crds/job.yaml
+++ b/charts/vertical-pod-autoscaler/templates/crds/job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/crds/serviceaccount.yaml
+++ b/charts/vertical-pod-autoscaler/templates/crds/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/clusterrolebinding.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/clusterrolebinding.yaml
@@ -17,4 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.recommender.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "vertical-pod-autoscaler.namespace" . | quote }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/metrics-service.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.metrics.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/pdb.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/serviceaccount.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.serviceAccountName" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/recommender/servicemonitor.yaml
+++ b/charts/vertical-pod-autoscaler/templates/recommender/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.recommender.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "vertical-pod-autoscaler.namespace" .) .Values.recommender.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.recommender.metrics.serviceMonitor.labels }}

--- a/charts/vertical-pod-autoscaler/templates/tests/configmap.yaml
+++ b/charts/vertical-pod-autoscaler/templates/tests/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "vertical-pod-autoscaler.tests.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.tests.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/tests/pod.yaml
+++ b/charts/vertical-pod-autoscaler/templates/tests/pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vertical-pod-autoscaler.tests.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.tests.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/updater/clusterrolebinding.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/clusterrolebinding.yaml
@@ -18,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.updater.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "vertical-pod-autoscaler.namespace" . | quote }}
 {{- end }}

--- a/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/updater/metrics-service.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.metrics.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/updater/pdb.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/updater/serviceaccount.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.serviceAccountName" . }}
+  namespace: {{ include "vertical-pod-autoscaler.namespace" . }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/vertical-pod-autoscaler/templates/updater/servicemonitor.yaml
+++ b/charts/vertical-pod-autoscaler/templates/updater/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.updater.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "vertical-pod-autoscaler.namespace" .) .Values.updater.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.updater.metrics.serviceMonitor.labels }}


### PR DESCRIPTION
In this PR I added two things:
- `metadata.namespace` to all (namespaced) resources
- ability to override this field to a custom namespace by adopting the "community standard" `.Values.namespaceOverride`

Some more details:

## Add `metadata.namespace`

There are tools which uses Helm only for templating (equivalent to `helm template .`):
- Kustomize (with `--enable-helm`)
- Argo CD
- CI scripts like
  - `helm template . | kubeconform ...`
  - `helm template . | kyverno apply -f -` (this is what I need for this chart 😄)

## Override via `.Values.namespaceOverride`

While I added the first "feature" to all resources, I thought that I create the common helper inside `_helpers.tpl` and add this to all resources instead of `{{ .Release.Namespace}}`.

I think the Helm chart community is heavily influenced by the Bitnami helm charts, they all support this, and many more.

## external references around those features:
- https://github.com/prometheus-community/helm-charts/issues/3472
- https://github.com/prometheus-community/helm-charts/pull/1878
- https://github.com/helm/charts/pull/18990
- https://github.com/helm/charts/pull/22288
- https://github.com/helm/charts/pull/18986
- https://github.com/kubernetes/ingress-nginx/pull/10539