### PR TITLE
chore/align Chart.yaml appVersion with app.

### DIFF
--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.4.0
+appVersion: 1.4.1
 description: Set of components that automatically adjust the amount of CPU and memory requested by pods running in the Kubernetes Cluster
 home: https://github.com/kubernetes/autoscaler
 icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
@@ -10,7 +10,7 @@ name: vertical-pod-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler
   - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 10.2.1
+version: 10.2.2
 dependencies:
   - name: common
     version: 2.31.1


### PR DESCRIPTION
### What this PR does / why we need it:

- Set Chart.yaml `appVersion` to the version actually used by default.